### PR TITLE
autodiscovery related fixes

### DIFF
--- a/chaps/__init__.py
+++ b/chaps/__init__.py
@@ -130,7 +130,7 @@ class Container(object):
         container.register_scope(SINGLETON_SCOPE, SingletonScope)
 
     @classmethod
-    def autodiscover(cls, path, subclass=None, profiles: set = frozenset()):
+    def autodiscover(cls, paths, subclass=None, profiles: set = frozenset()):
         """
         Autodiscover interfaces (bases) and implementations (services) in given
         path.
@@ -161,7 +161,7 @@ class Container(object):
                     results.update(walk(full_name))
             return results
 
-        walk(path)
+        [walk(path) for path in paths]
 
         config = {}
         for type_, qualifier, profile in dependency.implementations:

--- a/chaps/__init__.py
+++ b/chaps/__init__.py
@@ -2,7 +2,6 @@ import importlib
 import inspect
 import pkgutil
 import sys
-import functools
 
 from chaps.configparser import ConfigParser
 from chaps.scope.instance import InstanceScope
@@ -267,7 +266,6 @@ def dependency(cls=None, qualifier: str = None, profile: str = None):
         cls: implementation class (required)
         qualifier: required if there's another implementation registered
     """
-
     def __inner(cls_):
         assert cls_ is not None
         dependency.implementations.append((cls_, qualifier, profile))
@@ -277,6 +275,7 @@ def dependency(cls=None, qualifier: str = None, profile: str = None):
         return __inner(cls)
     else:
         return __inner
+
 
 dependency.implementations = list()
 

--- a/chaps/__init__.py
+++ b/chaps/__init__.py
@@ -67,6 +67,7 @@ class Container(object):
             Desired object instance from scope
         """
         try:
+            type_ = repr(type_)
             class_ = self.config[(type_, qualifier)]
         except KeyError:
             raise UnknownDependency(
@@ -96,6 +97,7 @@ class Container(object):
         self.scopes[name] = scope_class()
 
     def register_object(self, type_, class_, qualifier=None):
+        type_ = repr(type_)
         self.config[(type_, qualifier)] = class_
 
     @classmethod

--- a/chaps/__init__.py
+++ b/chaps/__init__.py
@@ -2,6 +2,7 @@ import importlib
 import inspect
 import pkgutil
 import sys
+import functools
 
 from chaps.configparser import ConfigParser
 from chaps.scope.instance import InstanceScope
@@ -270,11 +271,10 @@ def dependency(cls=None, qualifier: str = None, profile: str = None):
         dependency.implementations.append((cls_, qualifier, profile))
         return cls_
 
-    if qualifier is None:
+    if cls:
         return __inner(cls)
     else:
         return __inner
-
 
 dependency.implementations = list()
 


### PR DESCRIPTION
- fix `dependency` decorator
- allow multiple paths to be provided
- fix how keys are built: classes had had different ids on injections than while autodiscovery'ing, thus hashes differed and they could not be properly retrieved.